### PR TITLE
fix read-write race check in metrics middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/slok/goresilience
+module github.com/harssRajput/goresilience
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/metrics/runner.go
+++ b/metrics/runner.go
@@ -43,6 +43,7 @@ func NewMiddleware(id string, rec Recorder) goresilience.Middleware {
 	rec = rec.WithID(id)
 
 	return func(next goresilience.Runner) goresilience.Runner {
+		next = goresilience.SanitizeRunner(next)
 		return goresilience.RunnerFunc(func(ctx context.Context, f goresilience.Func) (err error) {
 			defer func(start time.Time) {
 				rec.ObserveCommandExecution(start, err == nil)
@@ -53,7 +54,6 @@ func NewMiddleware(id string, rec Recorder) goresilience.Middleware {
 			// by the context. Measure if this has a big impact.
 			ctx = SetRecorderOnContext(ctx, rec)
 
-			next = goresilience.SanitizeRunner(next)
 			err = next.Run(ctx, f)
 
 			return err


### PR DESCRIPTION
fix race condition that otherwise failing go -race check
changed module path so that we can GO GET it as a dependency until _**slok**_(repo owner) merge it in original repo.